### PR TITLE
Odyssey DLC fixes: vacsuits, ammo for Gravship scenario

### DIFF
--- a/Mods/CombatExtended/Odyssey/Patches/Scenarios/Scenarios_Odyssey.xml
+++ b/Mods/CombatExtended/Odyssey/Patches/Scenarios/Scenarios_Odyssey.xml
@@ -9,6 +9,11 @@
 				<thingDef>Ammo_45ACP_FMJ</thingDef>
 				<count>200</count>
 			</li>
+			<li Class="ScenPart_StartingThing_Defined">
+				<def>StartingThing_Defined</def>
+				<thingDef>Ammo_9x19mmPara_FMJ</thingDef>
+				<count>200</count>
+			</li>
 		</value>
 	</Operation>
 

--- a/Mods/Core_SK/Patches/SK_Patches_Odyssey_Gravship.xml
+++ b/Mods/Core_SK/Patches/SK_Patches_Odyssey_Gravship.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- Ensure CrewMember pawnkind generates with vacsuits equipped -->
+	<!-- HSK patches to BasePlayerPawnKind may break inherited vacsuit generation -->
+	<Operation Class="PatchOperationReplace" MayRequire="Ludeon.RimWorld.Odyssey">
+		<xpath>Defs/PawnKindDef[defName="CrewMember"]/apparelTags</xpath>
+		<value>
+			<apparelTags>
+				<li>Vacsuit</li>
+			</apparelTags>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace" MayRequire="Ludeon.RimWorld.Odyssey">
+		<xpath>Defs/PawnKindDef[defName="CrewMember"]/specificApparelRequirements</xpath>
+		<value>
+			<specificApparelRequirements>
+				<li>
+					<bodyPartGroup>FullHead</bodyPartGroup>
+					<requiredTag>Vacsuit</requiredTag>
+				</li>
+				<li>
+					<bodyPartGroup>Torso</bodyPartGroup>
+					<requiredTag>Vacsuit</requiredTag>
+				</li>
+			</specificApparelRequirements>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace" MayRequire="Ludeon.RimWorld.Odyssey">
+		<xpath>Defs/PawnKindDef[defName="CrewMember"]/ignoreApparelAllowChance</xpath>
+		<value>
+			<ignoreApparelAllowChance>true</ignoreApparelAllowChance>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace" MayRequire="Ludeon.RimWorld.Odyssey">
+		<xpath>Defs/PawnKindDef[defName="CrewMember"]/apparelAllowHeadgearChance</xpath>
+		<value>
+			<apparelAllowHeadgearChance>1</apparelAllowHeadgearChance>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace" MayRequire="Ludeon.RimWorld.Odyssey">
+		<xpath>Defs/PawnKindDef[defName="CrewMember"]/apparelMoney</xpath>
+		<value>
+			<apparelMoney>2500~4000</apparelMoney>
+		</value>
+	</Operation>
+
+</Patch>


### PR DESCRIPTION
## Summary
- Add 9x19mm Para ammo to Gravship scenario — Uzi (Gun_MachinePistol) uses 9x19mm in HSK but only .45 ACP was provided
- Add CrewMember PawnKindDef patch to ensure vacsuits are properly generated on all scenario pawns

## Changes
- `Mods/CombatExtended/Odyssey/Patches/Scenarios/Scenarios_Odyssey.xml` — add 200x Ammo_9x19mmPara_FMJ
- `Mods/Core_SK/Patches/SK_Patches_Odyssey_Gravship.xml` — re-apply vacsuit fields on CrewMember (apparelTags, specificApparelRequirements, ignoreApparelAllowChance, apparelAllowHeadgearChance, apparelMoney)

## Context
HSK's `SK.GeneratePawn_DefaultXenotypeRace_Patch.CopyPawnKindBasics()` in Core_SK.dll doesn't copy `specificApparelRequirements`, `ignoreApparelAllowChance`, and `apparelAllowHeadgearChance` when randomizing PawnKindDef for extra pawns. This causes non-CrewMember pawns in the selection pool to spawn without vacsuits. The XML patch works around this by explicitly setting these fields on CrewMember.

## Test plan
- [ ] Start Gravship scenario, verify all 8 pawns in selection screen wear vacsuits
- [ ] Verify Uzi has 9x19mm ammo available at game start
- [ ] Verify Autopistol still has .45 ACP ammo

🤖 Generated with [Claude Code](https://claude.com/claude-code)