### PR TITLE
fix: add 9x19mm ammo to Gravship scenario

### DIFF
--- a/Mods/CombatExtended/Odyssey/Patches/Scenarios/Scenarios_Odyssey.xml
+++ b/Mods/CombatExtended/Odyssey/Patches/Scenarios/Scenarios_Odyssey.xml
@@ -9,6 +9,11 @@
 				<thingDef>Ammo_45ACP_FMJ</thingDef>
 				<count>200</count>
 			</li>
+			<li Class="ScenPart_StartingThing_Defined">
+				<def>StartingThing_Defined</def>
+				<thingDef>Ammo_9x19mmPara_FMJ</thingDef>
+				<count>200</count>
+			</li>
 		</value>
 	</Operation>
 


### PR DESCRIPTION
## Summary
Gravship scenario includes Uzi (Gun_MachinePistol) which uses 9x19mm Para ammo in HSK. Only .45 ACP ammo was provided, which is used by the Autopistol but not by the Uzi. Added 200 rounds of 9x19mm Para FMJ.

## Changes
- `Mods/CombatExtended/Odyssey/Patches/Scenarios/Scenarios_Odyssey.xml` — add 200x Ammo_9x19mmPara_FMJ

## Test plan
- [ ] Start Gravship scenario, verify Uzi has 9x19mm ammo available
- [ ] Verify Autopistol still has .45 ACP ammo

🤖 Generated with [Claude Code](https://claude.com/claude-code)